### PR TITLE
Reutilização de Código

### DIFF
--- a/src/br/com/projeto/mock/FuncionariosMockDAO.java
+++ b/src/br/com/projeto/mock/FuncionariosMockDAO.java
@@ -19,30 +19,31 @@ public class FuncionariosMockDao implements FuncionariosDao {
 
     private void inicializarDadosMock() {
         funcionariosDataBase.add(new Funcionario("123456", "Administrador", "Administrador", 001, "Luiz Fernando",
-                "1123123", "12345678912", "teste@teste.com", "48912345678", "48912345678",
-                "12123000", "Rua Sem Nome", 69, "null",
+                "12.123.163-12", "123.456.789-12", "teste@teste.com", "(48) 91234-5678", "(48) 91234-5678",
+                "12123-000", "Rua Sem Nome", 69, "null",
                 "Agronomica", "Florianópolis", "SC"));
 
         funcionariosDataBase.add(new Funcionario("senha001", "Gerente", "Administrador", 002, "Ana Silva",
-                "22334455", "98765432100", "ana.silva@empresa.com", "48987654321", "48987654321",
-                "88034000", "Rua das Flores", 123, "Apt 101",
-                "Centro", "Florianópolis", "SC"));
+                "12.123.163-12", "987.654.321-00", "ana.silva@empresa.com", "(48) 98765-4321", "(48) 98765-4321",
+                "88034-000", "Rua das Flores", 123, "Apt 101",
+                "Centro", "Florianópolis", "RJ"));
 
         funcionariosDataBase.add(new Funcionario("senha002", "Analista", "Usuario", 003, "Carlos Souza",
-                "33445566", "12345678901", "carlos.souza@empresa.com", "48976543210", "48976543210",
-                "88035000", "Avenida Central", 456, "Bloco B",
+                "12.123.163-12", "123.456.789-01", "carlos.souza@empresa.com", "(48) 97654-3210", "(48) 97654-3210",
+                "88035-000", "Avenida Central", 456, "Bloco B",
                 "Trindade", "Florianópolis", "SC"));
 
         funcionariosDataBase.add(new Funcionario("senha003", "Desenvolvedor", "Usuario", 004, "Maria Oliveira",
-                "44556677", "98765432112", "maria.oliveira@empresa.com", "48965432109", "48965432109",
-                "88036000", "Rua do Sol", 789, "Casa 2",
-                "Coqueiros", "Florianópolis", "SC"));
+                "12.123.163-12", "987.654.321-12", "maria.oliveira@empresa.com", "(48) 96543-2109", "(48) 96543-2109",
+                "88036-000", "Rua do Sol", 789, "Casa 2",
+                "Coqueiros", "Florianópolis", "MG"));
 
         funcionariosDataBase.add(new Funcionario("senha004", "Tester", "Administrador", 005, "João Santos",
-                "55667788", "12345678923", "joao.santos@empresa.com", "48954321098", "48954321098",
-                "88037000", "Rua das Palmeiras", 101, "Apt 303",
+                "12.123.163-12", "123.456.789-23", "joao.santos@empresa.com", "(48) 95432-1098", "(48) 95432-1098",
+                "88037-000", "Rua das Palmeiras", 101, "Apt 303",
                 "Córrego Grande", "Florianópolis", "SC"));
     }
+
 
     @Override
     public void cadastrarFuncionarios(Funcionario obj) {

--- a/src/br/com/projeto/view/FrmFuncionario.java
+++ b/src/br/com/projeto/view/FrmFuncionario.java
@@ -14,16 +14,17 @@ import javax.swing.JOptionPane;
 public class FrmFuncionario extends javax.swing.JFrame {
 
     // Switch modo teste e modo de operação + criação do objeto para utilizar métodos
-    FuncionariosDao dataAccess = AppConfig.getFuncionariosDao();
-
+    private FuncionariosDao dataAccess = AppConfig.getFuncionariosDao();
+    private final DefaultTableModel model; 
+    
     public FrmFuncionario() {
         initComponents();
+        model = (DefaultTableModel) tableFuncionarios.getModel();
     }
 
     //Método Listar na Tabela
     public void listarFuncionarios() {
         List<Funcionario> listaFuncionarios = dataAccess.listarFuncionarios();
-        DefaultTableModel model = (DefaultTableModel) tableFuncionarios.getModel();
         model.setNumRows(0);
 
         for (Funcionario f : listaFuncionarios) {
@@ -37,14 +38,6 @@ public class FrmFuncionario extends javax.swing.JFrame {
                 f.getTelefone(),
                 f.getCidade(),
                 f.getUf()
-                //f.getRg(),
-                //f.getCpf(),             
-                //f.getSenha(),
-                //f.getCep(),
-                //f.getEndereco(),
-                //f.getNumero(),
-                //f.getComplemento(),
-                // f.getBairro()
             });
         }
     }
@@ -719,26 +712,17 @@ public class FrmFuncionario extends javax.swing.JFrame {
         try {
             String nome = "%" + textPesquisa.getText() + "%";
             List<Funcionario> listaFuncionarios = dataAccess.buscarFuncionario(nome);
-            DefaultTableModel dados = (DefaultTableModel) tableFuncionarios.getModel();
-            dados.setNumRows(0);
+            model.setNumRows(0);
 
             for (Funcionario f : listaFuncionarios) {
-                dados.addRow(new Object[]{
+                model.addRow(new Object[]{
                     f.getId(),
                     f.getNome(),
-                    f.getRg(),
-                    f.getCpf(),
-                    f.getEmail(),
-                    f.getSenha(),
                     f.getCargo(),
                     f.getNivelAcesso(),
-                    f.getTelefone(),
+                    f.getEmail(),
                     f.getCelular(),
-                    f.getCep(),
-                    f.getEndereco(),
-                    f.getNumero(),
-                    f.getComplemento(),
-                    f.getBairro(),
+                    f.getTelefone(),
                     f.getCidade(),
                     f.getUf()
                 });


### PR DESCRIPTION
- Reutilizado código `DefaultTableModel model = (DefaultTableModel) tableFuncionarios.getModel()`  que estava sendo chamado duas vezes em `FrmFuncionario`
- Alterados os dados dos funcionários fictícios de `FuncionariosMockDao`